### PR TITLE
fix: location.hash can be undefined when there is no hash used in the URL

### DIFF
--- a/ui.frontend/src/components/Title/title.class.ts
+++ b/ui.frontend/src/components/Title/title.class.ts
@@ -44,7 +44,7 @@ export class TitleComponent {
     }
 
     static get hashAnchor (): Element | null {
-        return document.querySelector(location.hash);
+        return location.hash ? document.querySelector(location.hash) : null;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
location.hash is empty on URLs without it i.e. www.example.com/index.html (note no # in the path)

## Description
<!--- Describe your changes in detail -->
Return null (it is allowed as a return value) and do not attempt to queryelement where there is no hash in location

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On each A element click without hash we get a console error

## Screenshots (if appropriate)
<img width="817" alt="Screenshot 2023-04-20 at 12 31 40" src="https://user-images.githubusercontent.com/121932253/233343073-237c51ba-6715-4f95-b86b-aa13b7209a11.png">


## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
