### PR TITLE
Fallback to initial content if RTE field is empty

### DIFF
--- a/core/src/main/java/pl/ds/howlite/components/models/QuoteComponent.java
+++ b/core/src/main/java/pl/ds/howlite/components/models/QuoteComponent.java
@@ -87,7 +87,7 @@ public class QuoteComponent implements Styled, Grid {
 
   @PostConstruct
   private void init() {
-    if ("<p></p>".equals(quoteText)) {
+    if (quoteText.isEmpty()) {
       quoteText = DEFAULT_QUOTE_TEXT;
     }
     initQuoteGridClasses();

--- a/core/src/main/java/pl/ds/howlite/components/models/RichTextComponent.java
+++ b/core/src/main/java/pl/ds/howlite/components/models/RichTextComponent.java
@@ -51,7 +51,7 @@ public class RichTextComponent implements Styled, Grid {
 
   @PostConstruct
   private void init() {
-    if ("<p></p>".equals(text)) {
+    if (text.isEmpty()) {
       text = DEFAULT_TEXT;
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The way we handle RTE fields with no content have changed and as a result my changes related to WS-2659 stopped working.

The root cause is that empty RTE field rendered empty p tag in the past but now empty string is rendered.

Due to this, I need to adjust the logic, so falling back to initial content is going to work again.

Justification: https://teamds.atlassian.net/browse/WOS-191

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
