### PR TITLE
[WOS-286] Adjust link util to work with the new publication model

### DIFF
--- a/core/src/main/java/pl/ds/howlite/components/utils/LinkUtil.java
+++ b/core/src/main/java/pl/ds/howlite/components/utils/LinkUtil.java
@@ -16,6 +16,8 @@
 
 package pl.ds.howlite.components.utils;
 
+import java.util.Objects;
+import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -26,6 +28,8 @@ import pl.ds.websight.assets.core.api.AssetsConstants;
 public class LinkUtil {
 
   private static final String ANCHOR_LINK_PREFIX = "#";
+  public static final String PUBLISHED = "/published";
+  public static final String CONTENT = "/content";
 
   private LinkUtil() {
     // no instance
@@ -49,7 +53,9 @@ public class LinkUtil {
     if (isAsset(link, resourceResolver)) {
       Asset asset = getAssetForProvidedLink(link, resourceResolver);
       if (asset != null && asset.getOriginalRendition() != null) {
-        return asset.getOriginalRendition().getPath();
+        return isPublished(link) ? RegExUtils.replaceFirst(asset.getOriginalRendition().getPath(),
+            CONTENT,
+            PUBLISHED) : asset.getOriginalRendition().getPath();
       }
 
       return null;
@@ -66,12 +72,12 @@ public class LinkUtil {
     return addProtocolPrefixToLink(link);
   }
 
-  private static boolean isInternal(String link, ResourceResolver resourceResolver) {
-    return resourceResolver.getResource(link) != null;
+  public static boolean isInternal(String link, ResourceResolver resourceResolver) {
+    return Objects.nonNull(getResource(link, resourceResolver));
   }
 
   private static boolean isAsset(String link, ResourceResolver resourceResolver) {
-    Resource resource = resourceResolver.getResource(link);
+    Resource resource = getResource(link, resourceResolver);
     return AssetsConstants.NT_ASSET.equals(getPrimaryType(resource));
   }
 
@@ -80,17 +86,34 @@ public class LinkUtil {
   }
 
   private static String addHtmlExtensionSuffixToLink(String link) {
-    return StringUtils.removeEnd(link, "/") + ".html";
+    String anchor = "";
+    if (link.contains(ANCHOR_LINK_PREFIX)) {
+      anchor = link.substring(link.lastIndexOf(ANCHOR_LINK_PREFIX));
+      link = link.substring(0, link.lastIndexOf(ANCHOR_LINK_PREFIX));
+    }
+
+    return StringUtils.removeEnd(link, "/") + ".html" + anchor;
   }
 
   @Nullable
   private static Asset getAssetForProvidedLink(String link, ResourceResolver resourceResolver) {
-    Resource assetResource = resourceResolver.getResource(link);
+    Resource assetResource = getResource(link, resourceResolver);
     Asset asset = null;
     if (assetResource != null) {
       asset = assetResource.adaptTo(Asset.class);
     }
     return asset;
+  }
+
+  public static Resource getResource(String link, ResourceResolver resourceResolver) {
+    if (link.startsWith(PUBLISHED)) {
+      return resourceResolver.getResource(link.replaceFirst(PUBLISHED, CONTENT));
+    }
+    return resourceResolver.getResource(link);
+  }
+
+  public static boolean isPublished(String link) {
+    return link.startsWith(PUBLISHED);
   }
 
   private static String getPrimaryType(Resource resource) {

--- a/core/src/test/java/pl/ds/howlite/components/utils/LinkUtilTest.java
+++ b/core/src/test/java/pl/ds/howlite/components/utils/LinkUtilTest.java
@@ -106,4 +106,16 @@ class LinkUtilTest {
         Assertions.assertThat(parsedLink).isEqualTo("#someAnchorLink");
     }
 
+    @Test
+    void handleInternalPageLinkWithAnchor() {
+        //given
+        Resource page = context.create().resource(PATH + "/internal/page/#anchorId");
+
+        //when
+        String parsedLink = LinkUtil.handleLink(page.getPath(), context.resourceResolver());
+
+        //then
+        Assertions.assertThat(parsedLink).isEqualTo("/content/test/internal/page.html#anchorId");
+    }
+
 }


### PR DESCRIPTION
Adjust link util to work with the new publication model

## Description
In the new publication model resources are moved to /published so, during the publication some of them can by not available, so link generated by LinkUtil can be invalid

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
