### PR TITLE
DSPL-233 add spacing between rich text and title

### DIFF
--- a/ui.frontend/src/components/RichText/rich-text.scss
+++ b/ui.frontend/src/components/RichText/rich-text.scss
@@ -21,7 +21,7 @@
 .hl-rich-text {
   text-align: left;
 
-  + .hl-rich-text {
+  + .hl-rich-text, + .hl-title {
     margin-top: map.get(abstracts.$spacing, 'medium-3');
   }
 

--- a/ui.frontend/src/components/Title/title.scss
+++ b/ui.frontend/src/components/Title/title.scss
@@ -19,6 +19,10 @@
 
 
 .hl-title {
+  + .hl-rich-text {
+    margin-top: map.get(abstracts.$spacing, 'medium-2');
+  }
+
   .subtitle {
     color: var(--color-default);
     line-height: 1.5rem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add spacing between rich text and title

## Motivation and Context
Currently there is no spacing when author places title and rich text below it. There is also no spacing when author places rich text and title below it.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
