### PR TITLE
DSPL-430 remove 'keywords' meta tag from Howlite page

### DIFF
--- a/core/src/main/resources/libs/howlite/components/page/head.html
+++ b/core/src/main/resources/libs/howlite/components/page/head.html
@@ -22,7 +22,6 @@
     <sly data-sly-test="${!title}">
         <title>${properties.jcr:title}</title>
     </sly>
-    <meta data-sly-test.keywords="${properties.keywords}" name="keywords" content="${keywords}"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta data-sly-test.description="${properties.description}" property="description" content="${description}"/>
     <meta data-sly-test.ogImage="${properties.ogImage}" property="og:image" content="${ogImage}"/>


### PR DESCRIPTION
'keywords' meta tag was removed from <head> on Howlite page.

## Motivation and Context
https://teamds.atlassian.net/browse/DSPL-430

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
